### PR TITLE
Corrections to dependencies and CRS test corrections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,19 +51,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.opengis.cite.teamengine</groupId>
+      <artifactId>teamengine-spi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opengis.cite</groupId>
       <artifactId>ets-gpkg12</artifactId>
       <version>0.7</version>
     </dependency>
     <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-epsg-hsql</artifactId>
-      <version>19.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-referencing</artifactId>
-      <version>19.1</version>
+      <groupId>org.opengis.cite</groupId>
+      <artifactId>geomatics-geotk</artifactId>
+      <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>javax.media</groupId>

--- a/src/main/java/org/opengis/cite/gpkg12/nsg/core/NSG_SpatialReferenceSystemsTests.java
+++ b/src/main/java/org/opengis/cite/gpkg12/nsg/core/NSG_SpatialReferenceSystemsTests.java
@@ -20,17 +20,25 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import org.geotools.referencing.CRS;
 import org.opengis.cite.gpkg12.CommonFixture;
 import org.opengis.cite.gpkg12.nsg.util.CrsList;
 import org.opengis.cite.gpkg12.nsg.util.CrsListingUtils;
 import org.opengis.cite.gpkg12.util.DatabaseUtility;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+
+import org.geotoolkit.factory.FactoryFinder;	 // Do NOT import the org.geotools.referencing.ReferencingFactoryFinder
+import org.opengis.referencing.crs.CRSFactory;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.cs.AxisDirection;
+import org.opengis.util.FactoryException;
+//import org.opengis.referencing.operation.CoordinateOperation;
+//import org.opengis.referencing.operation.CoordinateOperationFactory;
+
 
 public class NSG_SpatialReferenceSystemsTests extends CommonFixture {
 
@@ -43,6 +51,10 @@ public class NSG_SpatialReferenceSystemsTests extends CommonFixture {
     private static final double TOLERANCE = 1.0e-10;
 
     private CrsList crsListing;
+
+    /** Factory to create coordinate reference systems */
+    private CRSFactory crsFactory = org.geotoolkit.factory.FactoryFinder.getCRSFactory(null);  // we are calling it out specifically here due to conflicts with other packages.
+    
 
     @BeforeClass
     public void parseCrsListing() {
@@ -208,47 +220,81 @@ public class NSG_SpatialReferenceSystemsTests extends CommonFixture {
                     continue;
                 }
 
-                String definition = resultSet.getString( "definition" );
-                String expectedDefinition = crsListing.getDefinitionBySrsId( srsID );
-                if ( definition != null ) {
-                    boolean found = expectedDefinition != null && compareDefintion( definition, expectedDefinition );
-                    if ( !found ) {
-                        try {
-                            String code = "";
-                            try {
-                                // This call consistently fails with:
-                                // org.geotoolkit.referencing.factory.ReferencingObjectFactory cannot be cast to
-                                // org.opengis.referencing.Factory
-                                CoordinateReferenceSystem example = CRS.parseWKT( definition );
+                
+                // Get the current CRS definition and get from our saved specification,
+                // the CRS definition that we expect. Both of these are WKT.
+                final String defin = resultSet.getString( "definition" );
+                final String specin = crsListing.getDefinitionBySrsId( srsID );
 
-                                code = CRS.lookupIdentifier( example, true );
-                            } catch ( FactoryException e ) {
-                                invalidSrsDefs.add( srsID + ":" + definition + " : " + e.getMessage() );
-                                Assert.fail( MessageFormat.format( "The gpkg_spatial_ref_sys table error srs_id, wkt, error: {0}",
-                                                                   invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) ) );
-                            }
-                            try {
-                                CoordinateReferenceSystem decodedcrs = CRS.decode( code );
-                            } catch ( FactoryException e ) {
-                                invalidSrsDefs.add( srsID + ":" + definition + ": " + code + ":" + e.getMessage() );
-                                Assert.fail( MessageFormat.format( "The gpkg_spatial_ref_sys table contains invalid CRS defintions values for IDs {0}",
-                                                                   invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) ) );
-                            }
-                        } catch ( Exception ex ) { // The exectpin is consistently being caught from the CRS.parseWKT
-                            // fails with:
-                            // org.geotoolkit.referencing.factory.ReferencingObjectFactory cannot
-                            // be cast to org.opengis.referencing.Factory
-                            invalidSrsDefs.add( srsID + ":" + definition + " : " + ex.getMessage() );
-                            LOG.log( Level.WARNING,
-                                     "The gpkg_spatial_ref_sys table could not be examined for IDs due to processing exception.",
-                                     invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) );
-                            // Assert.fail( MessageFormat.format(
-                            // "The gpkg_spatial_ref_sys table could not be examined for IDs due to processing exception {0}",
-                            // invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) )
-                            // );
-                        }
-                    }
+            	boolean crsEquivalent = false;
+            	boolean parseFailure = false;
+            	
+            	CoordinateReferenceSystem testCRS = null;
+            	CoordinateReferenceSystem specCRS = null;
+
+    			// Parse WKT - this one is from the specification file
+    			try {
+    				specCRS = crsFactory.createFromWKT(specin);
+    			} catch (FactoryException e) {
+    				parseFailure = true;
+    				final String issueRpt = String.format(" Specification CRS WKT parse failure. WKT: %s : Failure Message : %s",
+    						specin, e.getMessage());
+                    invalidSrsDefs.add( issueRpt);
+                    LOG.log( Level.WARNING,
+                    		issueRpt,
+                             invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) );  
+    				//e.printStackTrace();
+    			}
+    			// Parse the WKT - this one is from the geopackage
+    			try {
+    				testCRS = crsFactory.createFromWKT(defin);
+    			} catch (FactoryException e) {
+    				parseFailure = true;
+    				final String issueRpt = String.format(" GeoPackage CRS WKT parse failure. WKT: %s : Failure Message : %s",
+    						defin, e.getMessage());
+                    invalidSrsDefs.add( issueRpt);
+                    LOG.log( Level.WARNING,
+                    		issueRpt,
+                             invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) );        			
+    				//e.printStackTrace();
+    			}
+
+
+        		// If they were actually both set, put them back out to WKT and now compare them
+        		// They should be mostly normalized now - However, there still may be spaces
+        		// in there that could cause a difference. Hence, we'll compare using a function that
+        		// strips spaces and moves all content to lower case.
+    			// This is still an extremely incomplete test and the CRSs may still be the same. In part,
+    			// this is due to different variations of WKT content.
+    			// We have found no WKT comparison utilities that will work.
+        		if (testCRS != null && specCRS != null) {
+        			
+        			crsEquivalent  = compareDefintion( testCRS.toWKT(), specCRS.toWKT() );
+        			
+        			// At this point we know the names from testCRS.getName() may still be different,
+        			// and the identifiers from testCRS.getIdentifiers() may be different, but these
+        			// may still be "the same" CRS. There is not much we can do about it given the available
+        			// utilities.
+       			
+        		}
+                
+        		// First type of failure is the failure to even parse the CRS WKT
+                if (parseFailure) {
+                	final String issueRpt = String.format("srs_id: %s : GeoPackage WKT: %s : Specification WKT: %s ", 
+                			srsID, defin, specin);
+            		invalidSrsDefs.add( issueRpt );
+                    Assert.fail( MessageFormat.format( "The CRS for srs_id is not equivalent to the specification due to failure in parsing the WKT.  {0}",
+                            invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) ) );                    	
                 }
+                // Next type of failure is if the test to see if the parsed WKTs are equivalent or not
+            	if (!crsEquivalent) {
+                	final String issueRpt = String.format("srs_id: %s : GeoPackage WKT (normalized): %s : Specification WKT (normalized): %s ", 
+                			srsID, testCRS.toWKT(), specCRS.toWKT());
+            		invalidSrsDefs.add( issueRpt );
+                    Assert.fail( MessageFormat.format( "The CRS for this srs_id is not exactly equivalent to the specification.  {0}",
+                            invalidSrsDefs.stream().map( Object::toString ).collect( Collectors.joining( ", " ) ) ) );                            		
+            	}
+           
             }
         }
     }

--- a/src/main/java/org/opengis/cite/gpkg12/nsg/tiles/NSG_TileTests.java
+++ b/src/main/java/org/opengis/cite/gpkg12/nsg/tiles/NSG_TileTests.java
@@ -54,14 +54,21 @@ public class NSG_TileTests extends CommonFixture {
      * 
      * @param inputString The string to validate
      * @return validated string
+     * @throws IllegalArgumentException if the input is found to be invalid
      */
-    public static String ValidateStringInput( String inputString ) {
+    public static String ValidateStringInput( String inputString ) throws IllegalArgumentException {
 
-    	String cleanStr = "";
+    	StringBuilder sb = new StringBuilder(50);  // initial size is 50. This is expected to be sufficient for most table and field names. This is NOT a limit.
     	for (int ii = 0; ii < inputString.length(); ++ii) {
-    		cleanStr += cleanChar(inputString.charAt(ii));
+    		final char cleanedchar = cleanChar(inputString.charAt(ii));
+    		if (cleanedchar == '^') {   // This is an illegal character indicator
+    			throw new IllegalArgumentException(String.format("Illegal parameter provided within SQL statement. Error in %s at character %c",inputString,  inputString.charAt(ii)));
+    		}
+    		else {
+    			sb.append(cleanedchar);
+    		}
     	}
-    	return cleanStr;
+    	return sb.toString();
     }
     
     /**
@@ -97,7 +104,7 @@ public class NSG_TileTests extends CommonFixture {
             case ' ':
                 return ' ';
         }
-        return '%';
+        return '^';
     }
 
     


### PR DESCRIPTION
Replace geotools references with geotoolkit capabilities. This removes the dependency on gt-reference, (and thereby removing the dependency on gt-metadata because it is a dependency of gt-reference). We know that gt-metadata causes problems when included as a dependency because it conflicts with other ets- packages. This should help with issue (although there may be other test packages that still include gt-metadata):
https://github.com/opengeospatial/ets-wfs20/issues/97

Verify all references used for CRS tests are correct, changing to the consistent and hopefully the better references.  While addressing the dependencies, verified all functions used for CRS tests are making use of the same dependency library and that that dependency is consistent with the factory finder - which for some reason has to come from a different dependency but at least it now is the correct factory finder dependency for this particular set of coordinate system dependencies.  This corrects the issue:
https://github.com/opengeospatial/ets-gpkg12-nsg/issues/35

Updated CRS tests to include capture of WKT parse problems.  The code performing the CRS tests was revised to accurately report WKT parse problems vs. issues with the WKT in the GeoPackage being different than the WKT specified. The code also notes that there are limitations. The WKT has several variants and details that could be included causing a failure for non-equivalence to the specification. Since the current WKT libraries do not allow for a generalized comparison, there is not much we can do about it without extensive development to handle WKT variations and comparison.
See issue:
https://github.com/opengeospatial/ets-gpkg12-nsg/issues/34  and
https://github.com/opengeospatial/ets-gpkg12-nsg/issues/27  

Updated SQL string verify for string operation optimizations. This update takes advantage of a performance enhancement that was added to the gpkg12 and will also help here.
